### PR TITLE
Added missing check for presence of username in password being checked

### DIFF
--- a/lib/active_model/validations/password_validator.rb
+++ b/lib/active_model/validations/password_validator.rb
@@ -8,6 +8,7 @@ class ActiveModel::Validations::PasswordValidator < ActiveModel::EachValidator
     password_too_long: 'is too long',
     not_enough_unique_characters: 'does not have enough unique characters',
     password_not_allowed: 'is not allowed',
+    banned_word_present: 'contains a banned word',
     password_too_common: 'is too common',
     fallback: 'is not valid'
   }

--- a/lib/active_model/validations/password_validator.rb
+++ b/lib/active_model/validations/password_validator.rb
@@ -1,6 +1,7 @@
 class ActiveModel::Validations::PasswordValidator < ActiveModel::EachValidator
   DEFAULT_ERROR_MESSAGES = {
     name_included_in_password: 'is too similar to your name',
+    username_included_in_password: 'is too similar to your username',
     email_included_in_password: 'is too similar to your email',
     domain_included_in_password: 'is too similar to this domain name',
     password_too_short: 'is too short',

--- a/lib/nobspw/configuration.rb
+++ b/lib/nobspw/configuration.rb
@@ -7,6 +7,7 @@ module NOBSPW
     attr_accessor :grep_path
     attr_accessor :domain_name
     attr_accessor :blacklist
+    attr_accessor :banned_words
     attr_accessor :validation_methods
     attr_accessor :interrupt_validation_for
 
@@ -18,6 +19,7 @@ module NOBSPW
       @grep_path                = `which grep`.strip
       @domain_name              = nil
       @blacklist                = nil
+      @banned_words             = nil
       @validation_methods       = NOBSPW::ValidationMethods::DEFAULT_VALIDATION_METHODS
       @interrupt_validation_for = NOBSPW::ValidationMethods::INTERRUPT_VALIDATION_FOR
     end

--- a/lib/nobspw/validation_methods.rb
+++ b/lib/nobspw/validation_methods.rb
@@ -2,6 +2,7 @@ module NOBSPW
   module ValidationMethods
     DEFAULT_VALIDATION_METHODS = %i(password_empty?
                                     name_included_in_password?
+                                    username_included_in_password?
                                     email_included_in_password?
                                     domain_included_in_password?
                                     password_too_short?
@@ -21,6 +22,12 @@ module NOBSPW
     def name_included_in_password?
       return nil unless @name
       words = remove_word_separators(@name).split(' ')
+      words_included_in_password?(words)
+    end
+
+    def username_included_in_password?
+      return nil unless @username
+      words = remove_word_separators(@username).split(' ')
       words_included_in_password?(words)
     end
 

--- a/lib/nobspw/validation_methods.rb
+++ b/lib/nobspw/validation_methods.rb
@@ -9,6 +9,7 @@ module NOBSPW
                                     password_too_long?
                                     not_enough_unique_characters?
                                     password_not_allowed?
+                                    banned_word_present?
                                     password_too_common?)
 
     INTERRUPT_VALIDATION_FOR   = %i(password_empty?)
@@ -48,6 +49,11 @@ module NOBSPW
     def password_not_allowed?
       return nil unless NOBSPW.configuration.blacklist
       NOBSPW.configuration.blacklist.include?(@password)
+    end
+
+    def banned_word_present?
+      return nil unless NOBSPW.configuration.banned_words
+      words_included_in_password?(NOBSPW.configuration.banned_words)
     end
 
     def password_too_short?

--- a/spec/lib/active_model/validations/password_validator_spec.rb
+++ b/spec/lib/active_model/validations/password_validator_spec.rb
@@ -61,6 +61,14 @@ RSpec.describe ActiveModel::Validations::PasswordValidator do
       end
     end
 
+    context "similar to user's username" do
+      it 'is a weak password' do
+        user.password = 'iamcoolboy13'
+        expect(user).to_not be_valid
+        expect(user.errors[:password]).to include 'is too similar to your username'
+      end
+    end
+
     context "similar to user's email" do
       it 'is a weak password' do
         user.password = 'microsoftworld'

--- a/spec/lib/active_model/validations/password_validator_spec.rb
+++ b/spec/lib/active_model/validations/password_validator_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe ActiveModel::Validations::PasswordValidator do
     NOBSPW.configure do |config|
       config.domain_name = 'example.org'
       config.blacklist = %w(thispasswordisblacklisted)
+      config.banned_words = %w(banana)
     end
   }
 
@@ -90,6 +91,14 @@ RSpec.describe ActiveModel::Validations::PasswordValidator do
         user.password = 'thispasswordisblacklisted'
         expect(user).to_not be_valid
         expect(user.errors[:password]).to include 'is not allowed'
+      end
+    end
+
+    context 'banned word' do
+      it 'is a weak password' do
+        user.password = 'thispasswordisbanana'
+        expect(user).to_not be_valid
+        expect(user.errors[:password]).to include 'contains a banned word'
       end
     end
 

--- a/spec/lib/nobspw/password_checker_spec.rb
+++ b/spec/lib/nobspw/password_checker_spec.rb
@@ -67,6 +67,16 @@ RSpec.describe NOBSPW::PasswordChecker do
       end
     end
 
+    context 'username is included in password' do
+      let(:password) { 'iamjohnthegreat' }
+      let(:username) { 'johnthegreat'}
+
+      it 'fails as it should' do
+        expect(pc).to be_weak
+        expect(pc.reasons).to include(:username_included_in_password)
+      end
+    end
+
     context 'email username is included in password' do
       let(:password) { 'iamjohnthegreat' }
       let(:email)    { 'john.draper@microsoft.com'}

--- a/spec/lib/nobspw/password_checker_spec.rb
+++ b/spec/lib/nobspw/password_checker_spec.rb
@@ -181,6 +181,21 @@ RSpec.describe NOBSPW::PasswordChecker do
       end
     end
 
+    context 'password contains banned work' do
+      before(:each) do
+        NOBSPW.configure do |config|
+          config.banned_words = %w(password banana)
+        end
+      end
+
+      let(:password) { 'thispasswordisblacklisted' }
+
+      it 'fails as it should' do
+        expect(pc).to be_weak
+        expect(pc.reasons).to include(:banned_word_present)
+      end
+    end
+
     context 'perfectly fine password' do
       let(:password) { 'this-is-a-valid-password' }
 


### PR DESCRIPTION
Existing code implies that it checks for existence of `username` in the password, but this does not in fact happen. Have added the required code.