### PR TITLE
use Ruby internal tooling to avoid argument leakage

### DIFF
--- a/lib/nobspw/password_checker.rb
+++ b/lib/nobspw/password_checker.rb
@@ -37,8 +37,5 @@ module NOBSPW
       @strong = @weak_password_reasons.empty?
     end
 
-    def grep_command(path)
-      "#{NOBSPW.configuration.grep_path} '^#{@password}$' #{path}"
-    end
   end
 end

--- a/lib/nobspw/validation_methods.rb
+++ b/lib/nobspw/validation_methods.rb
@@ -65,10 +65,10 @@ module NOBSPW
     end
 
     def password_too_common?
-      res = File.foreach(NOBSPW.configuration.dictionary_path) do |line|
-        return true if line =~ /^#{@password}$/
-      end
-      return false
+      occurrences = File
+                      .open(NOBSPW.configuration.dictionary_path)
+                      .grep(/^#{@password}$/)
+      return occurrences.any?
     end
 
     # Helper methods

--- a/lib/nobspw/validation_methods.rb
+++ b/lib/nobspw/validation_methods.rb
@@ -65,18 +65,10 @@ module NOBSPW
     end
 
     def password_too_common?
-      `#{grep_command(NOBSPW.configuration.dictionary_path)}`
-
-      case $?.exitstatus
-      when 0
-        true
-      when 1
-        false
-      when 127
-        raise StandardError.new("Grep not found at: #{NOBSPW.configuration.grep_path}")
-      else
-        false
+      res = File.foreach(NOBSPW.configuration.dictionary_path) do |line|
+        return true if line =~ /^#{@password}$/
       end
+      return false
     end
 
     # Helper methods


### PR DESCRIPTION
Arguments to processes (here: `grep`) are world-readable (at least in the Linux kernel) and can be inspected, for example, via `ps -ejHf`. Thus, the following line leaks the passwords/secrets to all users (or even loggers!) of the OS

https://github.com/cmer/nobspw/issues/6

