### PR TITLE
Fixed spelling mistake

### DIFF
--- a/lib/nobspw/validation_methods.rb
+++ b/lib/nobspw/validation_methods.rb
@@ -96,7 +96,7 @@ module NOBSPW
         if !File.exist?(NOBSPW.configuration.grep_path)
 
       output = Open3.popen3(STDIN_GREP_COMMAND.join(" "), out: '/dev/null') { |stdin, stdout, stderr, wait_thr|
-        stdin.puts "^#{excaped_password}$"
+        stdin.puts "^#{escaped_password}$"
         stdin.close
         wait_thr.value
       }


### PR DESCRIPTION
After upgrading to version 0.6.0, my rspec test suite started giving the following error which I tracked down to a simple spelling mistake:
```
 NameError:
       undefined local variable or method `excaped_password' for #<NOBSPW::PasswordChecker:0x00007fa7c23e3a98>
       Did you mean?  escaped_password
```