### PR TITLE
Don’t depend on ActiveSupport’s #present?

### DIFF
--- a/lib/nobspw/configuration.rb
+++ b/lib/nobspw/configuration.rb
@@ -17,7 +17,7 @@ module NOBSPW
       @min_unique_characters    = 5
       @dictionary_path          = File.join(File.dirname(__FILE__), "..", "db", "dictionary.txt")
       @grep_path                = `which grep`.strip
-      @use_ruby_grep            = !@grep_path.present?
+      @use_ruby_grep            = @grep_path.empty?
       @domain_name              = nil
       @blacklist                = nil
       @validation_methods       = NOBSPW::ValidationMethods::DEFAULT_VALIDATION_METHODS

--- a/lib/nobspw/validation_methods.rb
+++ b/lib/nobspw/validation_methods.rb
@@ -104,7 +104,7 @@ module NOBSPW
     end
 
     def ruby_grep
-      File.open(NOBSPW.configuration.dictionary_path).grep(/^#{escaped_password}$/).present?
+      File.open(NOBSPW.configuration.dictionary_path).grep(/^#{escaped_password}$/).any?
     end
 
     def email_without_extension(email)

--- a/spec/lib/nobspw/password_checker_spec.rb
+++ b/spec/lib/nobspw/password_checker_spec.rb
@@ -47,8 +47,9 @@ RSpec.describe NOBSPW::PasswordChecker do
 
     context 'password is too long' do
       let(:password) do
+        alphabet = ('0'..'9').to_a + ('a'..'z').to_a
         length = NOBSPW.configuration.max_password_length + 1
-        rand(36**length).to_s(36)
+        length.times.map { alphabet.sample }.join
       end
 
       it 'fails as it should' do


### PR DESCRIPTION
`#present?` was used in a couple spots and `activesupport` is not listed as a gem dependency. I figured it was nicer to avoid it than to add the dependency.

Not sure how we could actually reflect that change in specs. My testing method was pretty much:

1. Comment out `require 'active_model'` in `spec_helper.rb`
2. Comment out all of `password_validator_spec.rb`
3. Ensure all other specs pass

Regarding the unrelated spec fix, I can’t explain exactly what the `rand` business was previously doing but I did get that spec to fails a few times; password length was 256 and not 257.