### PR TITLE
Replacing Deprecated method of adding errors to ActiveModel

### DIFF
--- a/lib/active_model/validations/password_validator.rb
+++ b/lib/active_model/validations/password_validator.rb
@@ -19,7 +19,7 @@ class ActiveModel::Validations::PasswordValidator < ActiveModel::EachValidator
                                      username: username_value(record)
 
     pc.weak_password_reasons.each do |reason|
-      record.errors[attribute] << get_message(reason)
+      record.errors.add(attribute, get_message(reason))
     end
     pc.strong?
   end


### PR DESCRIPTION
Using << to add to an ActiveModel error message array is deprecated in Rails 7